### PR TITLE
[chore/1-entity] 기본 생성자 access level protected로 설정

### DIFF
--- a/src/main/java/com/kkobugi/puremarket/giveaway/domain/entity/Giveaway.java
+++ b/src/main/java/com/kkobugi/puremarket/giveaway/domain/entity/Giveaway.java
@@ -3,13 +3,14 @@ package com.kkobugi.puremarket.giveaway.domain.entity;
 import com.kkobugi.puremarket.common.BaseEntity;
 import com.kkobugi.puremarket.user.domain.entity.User;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DynamicInsert
 public class Giveaway extends BaseEntity {
     @Id

--- a/src/main/java/com/kkobugi/puremarket/ingredient/domain/entity/Ingredient.java
+++ b/src/main/java/com/kkobugi/puremarket/ingredient/domain/entity/Ingredient.java
@@ -4,13 +4,14 @@ import com.kkobugi.puremarket.common.BaseEntity;
 import com.kkobugi.puremarket.common.enums.IngredientType;
 import com.kkobugi.puremarket.recipe.domain.entity.Recipe;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DynamicInsert
 public class Ingredient extends BaseEntity {
     @Id

--- a/src/main/java/com/kkobugi/puremarket/produce/domain/entity/Produce.java
+++ b/src/main/java/com/kkobugi/puremarket/produce/domain/entity/Produce.java
@@ -3,6 +3,7 @@ package com.kkobugi.puremarket.produce.domain.entity;
 import com.kkobugi.puremarket.common.BaseEntity;
 import com.kkobugi.puremarket.user.domain.entity.User;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,7 +11,7 @@ import org.hibernate.annotations.DynamicInsert;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DynamicInsert
 public class Produce extends BaseEntity {
     @Id

--- a/src/main/java/com/kkobugi/puremarket/recipe/domain/entity/Recipe.java
+++ b/src/main/java/com/kkobugi/puremarket/recipe/domain/entity/Recipe.java
@@ -3,13 +3,14 @@ package com.kkobugi.puremarket.recipe.domain.entity;
 import com.kkobugi.puremarket.common.BaseEntity;
 import com.kkobugi.puremarket.user.domain.entity.User;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DynamicInsert
 public class Recipe extends BaseEntity {
     @Id

--- a/src/main/java/com/kkobugi/puremarket/recipe/domain/entity/RecipeDescription.java
+++ b/src/main/java/com/kkobugi/puremarket/recipe/domain/entity/RecipeDescription.java
@@ -2,13 +2,14 @@ package com.kkobugi.puremarket.recipe.domain.entity;
 
 import com.kkobugi.puremarket.common.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DynamicInsert
 public class RecipeDescription extends BaseEntity { // 레시피 상세
     @Id

--- a/src/main/java/com/kkobugi/puremarket/user/domain/entity/User.java
+++ b/src/main/java/com/kkobugi/puremarket/user/domain/entity/User.java
@@ -2,6 +2,7 @@ package com.kkobugi.puremarket.user.domain.entity;
 
 import com.kkobugi.puremarket.common.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,7 +12,7 @@ import static com.kkobugi.puremarket.common.constants.Constant.*;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DynamicInsert
 public class User extends BaseEntity {
     @Id


### PR DESCRIPTION
## 📌 이슈 번호
#1

## 📢 의논 사항
- @NoArgsConstructor의 access level을 protected로 설정해 무분별한 객체 생성을 방지
